### PR TITLE
Use  UIManager.createLookAndFeel(lafName) in DarculaLaf constructor

### DIFF
--- a/src/com/bulenkov/darcula/DarculaLaf.java
+++ b/src/com/bulenkov/darcula/DarculaLaf.java
@@ -58,8 +58,13 @@ public final class DarculaLaf extends BasicLookAndFeel {
         base = new MetalLookAndFeel();
         MetalLookAndFeel.setCurrentTheme(new DarculaMetalTheme());
       } else {
-        final String name = UIManager.getSystemLookAndFeelClassName();
-        base = (BasicLookAndFeel)Class.forName(name).newInstance();
+        final String lafClassName = UIManager.getSystemLookAndFeelClassName();
+        for(UIManager.LookAndFeelInfo info: UIManager.getInstalledLookAndFeels()) {
+          if(info.getClassName().equals(lafClassName)) {
+            base = (BasicLookAndFeel) UIManager.createLookAndFeel(info.getName());
+            break;
+          }
+        }
       }
     }
     catch (Exception ignore) {


### PR DESCRIPTION
This is a proposal to use UIManager.createLookAndFeel(lafName) method in DarculaLaf constructor instead of creating a L&F via reflection.
The L&F necessary for createLookAndFeel(lafName) method is retrieved from installed L&F infos.